### PR TITLE
window is undefined when creating worker-in-worker

### DIFF
--- a/createInlineWorker.js
+++ b/createInlineWorker.js
@@ -1,23 +1,25 @@
 // http://stackoverflow.com/questions/10343913/how-to-create-a-web-worker-from-a-string
 
-var URL = window.URL || window.webkitURL;
-module.exports = function(content, url) {
-	try {
+(function (w) {
+	var URL = w.URL || w.webkitURL;
+	module.exports = function(content, url) {
 		try {
-			var blob;
-			try { // BlobBuilder = Deprecated, but widely implemented
-				var BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder || window.MSBlobBuilder;
-				blob = new BlobBuilder();
-				blob.append(content);
-				blob = blob.getBlob();
-			} catch(e) { // The proposed API
-				blob = new Blob([content]);
+			try {
+				var blob;
+				try { // BlobBuilder = Deprecated, but widely implemented
+					var BlobBuilder = w.BlobBuilder || w.WebKitBlobBuilder || w.MozBlobBuilder || w.MSBlobBuilder;
+					blob = new BlobBuilder();
+					blob.append(content);
+					blob = blob.getBlob();
+				} catch(e) { // The proposed API
+					blob = new Blob([content]);
+				}
+				return new Worker(URL.createObjectURL(blob));
+			} catch(e) {
+				return new Worker('data:application/javascript,' + encodeURIComponent(content));
 			}
-			return new Worker(URL.createObjectURL(blob));
 		} catch(e) {
-			return new Worker('data:application/javascript,' + encodeURIComponent(content));
+			return new Worker(url);
 		}
-	} catch(e) {
-		return new Worker(url);
 	}
-}
+}(this));


### PR DESCRIPTION
When creating an inline worker inside of another worker, an error is thrown because this code uses "window" rather than "self" to create the URL and BlobBuilder.

I've tested that this fix works for my use-case.  Hoping you can pull this in if it works for you!
